### PR TITLE
Fix error in settings pane

### DIFF
--- a/src/components/Ui/Main/Main.js
+++ b/src/components/Ui/Main/Main.js
@@ -143,9 +143,8 @@ class AppMain extends Component {
 
     this.writeUserSettings()
 
-    if (e.target.checked) {
+    if (this.state.darkMode) {
       require('./style.css')
-
     } else {
       require('./style-light.css')
     }


### PR DESCRIPTION
Error: `e.target.checked` loses it's value after executing `this.writeUserSettings`, making the following read of the property result in the following screen:
![image](https://user-images.githubusercontent.com/32309574/71506917-bba05b80-28bd-11ea-892b-c3c2953850d2.png)
I've fixed it by using the value stored in the state instead. Overall it's a very simple fix, just helping out in what I can.