### PR TITLE
Apply minor aesthetic change

### DIFF
--- a/src/components/App/style.css
+++ b/src/components/App/style.css
@@ -28,7 +28,8 @@ body {
 
 #accountsFormLeft {
     text-align: left;
-    padding-left: 40%;
+	width: fit-content;
+	display: inline-block;
 }
 
 #modalFormLeft {


### PR DESCRIPTION
# Description
When trying a different aspect ratio the content overflows outside of the screen due to the fact that the padding is hardcoded to 40%, I've changed it to center the content dynamically.

## Before
![image](https://user-images.githubusercontent.com/32309574/71508679-9b739b00-28c3-11ea-9d25-fd1b9ed5c964.png)
## After 
![image](https://user-images.githubusercontent.com/32309574/71508693-a3cbd600-28c3-11ea-8001-9b04904598a6.png)
## Normal ratio
It also centers the content properly when using a normal aspect ratio:
![image](https://user-images.githubusercontent.com/32309574/71508739-ccec6680-28c3-11ea-8363-4d71f3a91de7.png)
